### PR TITLE
Fixing numba dependency errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas==1.0.3
 matplotlib==3.1
 
 numba==0.46
-llvmlite==0.32.1
+llvmlite==0.30
 
 pynndescent
 umap-learn==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ matplotlib==3.1
 numba==0.46
 llvmlite==0.30
 
-pynndescent
+pynndescent==0.4.8
 umap-learn==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ numpy==1.18
 pandas==1.0.3
 matplotlib==3.1
 
-numba==0.47
+numba==0.46
 pynndescent
 umap-learn==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ numpy==1.18
 pandas==1.0.3
 matplotlib==3.1
 
-numba
+numba==0.47
 pynndescent
 umap-learn==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,7 @@ pandas==1.0.3
 matplotlib==3.1
 
 numba==0.46
+llvmlite==0.32.1
+
 pynndescent
 umap-learn==0.4


### PR DESCRIPTION
Explicitly reverting to known good package combination of numba 0.46 + llvmlite 0.30